### PR TITLE
Set b:undo_ftplugin

### DIFF
--- a/autoload/ada.vim
+++ b/autoload/ada.vim
@@ -497,6 +497,9 @@ function ada#Map_Menu (Text, Keys, Command, Function, Args)
 	    execute "inoremap <unique>"  . l:mapping  .                   " <C-O>:" . a:Command . "<CR>"
 	    execute "50amenu " . "&Ada." . l:menutext . "<Tab>:" . l:mapping . " :" . a:Command . "<CR>"
 	 endif
+	 " TODO: consider removing buffer-specific commands
+	 let b:undo_ftplugin .= " | silent! execute 'nunmap "  . l:mapping . "'" .
+		  \             " | silent! execute 'iunmap "  . l:mapping . "'"
       endif
    else
       if a:Args == ''

--- a/ftplugin/ada.vim
+++ b/ftplugin/ada.vim
@@ -52,19 +52,27 @@ setlocal comments=O:--,:--\ \
 setlocal commentstring=--\ \ %s
 setlocal complete=.,w,b,u,t,i
 
+let b:undo_ftplugin = "setlocal comments< commentstring< complete<"
+
 " Section: case	     {{{1
 "
 setlocal nosmartcase
 setlocal ignorecase
 
+let b:undo_ftplugin .= " | setlocal smartcase< ignorecase<"
+
 " Section: formatoptions {{{1
 "
 setlocal formatoptions+=ron
+
+let b:undo_ftplugin .= " | setlocal formatoptions<"
 
 " Section: Completion {{{1
 "
 setlocal completefunc=ada#User_Complete
 setlocal omnifunc=adacomplete#Complete
+
+let b:undo_ftplugin .= " | setlocal completefunc< omnifunc<"
 
 if exists ("g:ada_extended_completion")
    if mapcheck ('<C-N>','i') == ''
@@ -79,6 +87,10 @@ if exists ("g:ada_extended_completion")
    if mapcheck ('<bs>','i') == ''
       inoremap <silent> <unique> <buffer> <bs> <C-R>=ada#Insert_Backspace ()<cr>
    endif
+   let b:undo_ftplugin .= " | silent! execute 'iunmap <buffer> <C-N>'" .
+	    \             " | silent! execute 'iunmap <buffer> <C-P>'" .
+	    \             " | silent! execute 'iunmap <buffer> <C-X><C-]>'" .
+	    \             " | silent! execute 'iunmap <buffer> <bs>'"
 endif
 
 " Section: Matchit {{{1
@@ -98,6 +110,7 @@ if !exists ("b:match_words")  &&
       \ '\%(\<while\>.*\|\<for\>.*\|'.s:notend.'\)\<loop\>:\<end\>\s\+\<loop\>,' .
       \ '\%(\<do\>\|\<begin\>\):\<exception\>:\<end\>\s*\%($\|[;A-Z]\),' .
       \ s:notend . '\<record\>:\<end\>\s\+\<record\>'
+   let b:undo_ftplugin .= " | unlet! b:match_words"
 endif
 
 
@@ -119,24 +132,32 @@ if exists("g:ada_folding")
       setlocal foldmethod=indent
       setlocal foldignore=--
       setlocal foldnestmax=5
+      let b:undo_ftplugin .= " | setlocal foldmethod< foldignore< foldnestmax<"
    elseif g:ada_folding[0] == 'g'
       setlocal foldmethod=expr
       setlocal foldexpr=ada#Pretty_Print_Folding(v:lnum)
+      let b:undo_ftplugin .= " | setlocal foldmethod< foldexpr<"
    elseif g:ada_folding[0] == 's'
       setlocal foldmethod=syntax
+      let b:undo_ftplugin .= " | setlocal foldmethod<"
    endif
    setlocal tabstop=8
    setlocal softtabstop=3
    setlocal shiftwidth=3
+   let b:undo_ftplugin .= " | setlocal tabstop< softtabstop< shiftwidth<"
 endif
 
 " Section: Abbrev {{{1
 "
 if exists("g:ada_abbrev")
-   iabbrev ret	return
-   iabbrev proc procedure
-   iabbrev pack package
-   iabbrev func function
+   iabbrev <buffer> ret return
+   iabbrev <buffer> proc procedure
+   iabbrev <buffer> pack package
+   iabbrev <buffer> func function
+   let b:undo_ftplugin .= " | iunabbrev <buffer> ret" .
+	    \		  " | iunabbrev <buffer> proc" .
+	    \		  " | iunabbrev <buffer> pack" .
+	    \		  " | iunabbrev <buffer> func"
 endif
 
 " Section: Commands, Mapping, Menus {{{1

--- a/ftplugin/ada.vim
+++ b/ftplugin/ada.vim
@@ -110,7 +110,7 @@ if !exists ("b:match_words")  &&
       \ '\%(\<while\>.*\|\<for\>.*\|'.s:notend.'\)\<loop\>:\<end\s\+loop\>,' .
       \ '\%(\<do\>\|\<begin\>\):\<exception\>:\<end\%(\s*\%($\|;\)\|\s\+\%(\%(if\|case\|loop\|record\)\>\)\@!\a\)\@=,' .
       \ s:notend . '\<record\>:\<end\s\+record\>'
-   let b:undo_ftplugin .= " | unlet! b:match_words"
+   let b:undo_ftplugin .= " | unlet! b:match_skip b:match_words"
    let b:match_skip = 's:Comment\|String\|Operator'
 endif
 


### PR DESCRIPTION
Filetype plugins should set b:undo_ftplugin to a command string that, when evaluated upon a filetype change, will undo any configuration changes made by the plugin.  See :help undo_ftplugin for details.

Fixes #21.

@krischik, just ignore this for the moment if you like.  It needs testing and further work.