### PR TITLE
Improve matchit config

### DIFF
--- a/ftplugin/ada.vim
+++ b/ftplugin/ada.vim
@@ -93,11 +93,11 @@ if !exists ("b:match_words")  &&
    "
    let s:notend      = '\%(\<end\s\+\)\@<!'
    let b:match_words =
-      \ s:notend . '\<if\>:\<elsif\>:\<\%(or\s\)\@3<!else\>:\<end\>\s\+\<if\>,' .
-      \ s:notend . '\<case\>:\<when\>:\<end\>\s\+\<case\>,' .
-      \ '\%(\<while\>.*\|\<for\>.*\|'.s:notend.'\)\<loop\>:\<end\>\s\+\<loop\>,' .
+      \ s:notend . '\<if\>:\<elsif\>:\<\%(or\s\)\@3<!else\>:\<end\s\+if\>,' .
+      \ s:notend . '\<case\>:\<when\>:\<end\s\+case\>,' .
+      \ '\%(\<while\>.*\|\<for\>.*\|'.s:notend.'\)\<loop\>:\<end\s\+loop\>,' .
       \ '\%(\<do\>\|\<begin\>\):\<exception\>:\<end\%(\s*\%($\|;\)\|\s\+\%(\%(if\|case\|loop\|record\)\>\)\@!\a\)\@=,' .
-      \ s:notend . '\<record\>:\<end\>\s\+\<record\>'
+      \ s:notend . '\<record\>:\<end\s\+record\>'
    let b:match_skip = 's:Comment\|String\|Operator'
 endif
 

--- a/ftplugin/ada.vim
+++ b/ftplugin/ada.vim
@@ -96,7 +96,7 @@ if !exists ("b:match_words")  &&
       \ s:notend . '\<if\>:\<elsif\>:\<else\>:\<end\>\s\+\<if\>,' .
       \ s:notend . '\<case\>:\<when\>:\<end\>\s\+\<case\>,' .
       \ '\%(\<while\>.*\|\<for\>.*\|'.s:notend.'\)\<loop\>:\<end\>\s\+\<loop\>,' .
-      \ '\%(\<do\>\|\<begin\>\):\<exception\>:\<end\>\s*\%($\|[;A-Z]\),' .
+      \ '\%(\<do\>\|\<begin\>\):\<exception\>:\<end\%(\s*\%($\|;\)\|\s\+\%(\%(if\|case\|loop\|record\)\>\)\@!\a\)\@=,' .
       \ s:notend . '\<record\>:\<end\>\s\+\<record\>'
 endif
 

--- a/ftplugin/ada.vim
+++ b/ftplugin/ada.vim
@@ -93,11 +93,12 @@ if !exists ("b:match_words")  &&
    "
    let s:notend      = '\%(\<end\s\+\)\@<!'
    let b:match_words =
-      \ s:notend . '\<if\>:\<elsif\>:\<else\>:\<end\>\s\+\<if\>,' .
+      \ s:notend . '\<if\>:\<elsif\>:\<\%(or\s\)\@3<!else\>:\<end\>\s\+\<if\>,' .
       \ s:notend . '\<case\>:\<when\>:\<end\>\s\+\<case\>,' .
       \ '\%(\<while\>.*\|\<for\>.*\|'.s:notend.'\)\<loop\>:\<end\>\s\+\<loop\>,' .
       \ '\%(\<do\>\|\<begin\>\):\<exception\>:\<end\%(\s*\%($\|;\)\|\s\+\%(\%(if\|case\|loop\|record\)\>\)\@!\a\)\@=,' .
       \ s:notend . '\<record\>:\<end\>\s\+\<record\>'
+   let b:match_skip = 's:Comment\|String\|Operator'
 endif
 
 


### PR DESCRIPTION
- Fix matchit handling of nested blocks
- Fix matchit handling of "or else" operator in if statements
- Remove redundant word boundary atoms from b:match_words pattern

