### PR TITLE
Fix folding close marker level indicators

### DIFF
--- a/ada_options.vim
+++ b/ada_options.vim
@@ -21,7 +21,7 @@
 "------------------------------------------------------------------------------
 
 echoerr 'It is suggested to copy the content of ada_options into .vimrc!'
-finish " 1}}}
+finish
 
 " Section: Ada options {{{1
 

--- a/autoload/ada.vim
+++ b/autoload/ada.vim
@@ -170,7 +170,7 @@ if exists ('g:ada_gnat_extensions')
 		\ 'icase': 1}]
     endfor
 endif
-" 1}}}
+" }}}1
 
 " Section: g:ada#Ctags_Kinds {{{1
 "
@@ -525,7 +525,7 @@ lockvar! g:ada#Ctags_Kinds
 let &cpo = s:keepcpo
 unlet s:keepcpo
 
-finish " 1}}}
+finish " }}}1
 
 "------------------------------------------------------------------------------
 "   Vim is Charityware - see ":help license" or uganda.txt for licence details.

--- a/autoload/adacomplete.vim
+++ b/autoload/adacomplete.vim
@@ -95,7 +95,7 @@ function! adacomplete#Complete (findstart, base)
    endif
 endfunction adacomplete#Complete
 
-finish " 1}}}
+finish " }}}1
 
 "------------------------------------------------------------------------------
 "   Vim is Charityware - see ":help license" or uganda.txt for licence details.

--- a/autoload/alire.vim
+++ b/autoload/alire.vim
@@ -72,7 +72,7 @@ function alire#New ()						     " {{{1
    return l:Retval
 endfunction alire#New						  " }}}1
 
-finish " 1}}}
+finish " }}}1
 
 "------------------------------------------------------------------------------
 "   Vim is Charityware - see ":help license" or uganda.txt for licence details.

--- a/autoload/gnat.vim
+++ b/autoload/gnat.vim
@@ -118,7 +118,7 @@ function gnat#New ()						     " {{{1
    return l:Retval
 endfunction gnat#New						  " }}}1
 
-finish " 1}}}
+finish " }}}1
 
 "------------------------------------------------------------------------------
 "   Vim is Charityware - see ":help license" or uganda.txt for licence details.

--- a/compiler/alire.vim
+++ b/compiler/alire.vim
@@ -74,7 +74,7 @@ if exists("g:ada_create_session")
    call ada#Switch_Session('alire.vim')
 endif
 
-finish " 1}}}
+finish " }}}1
 
 "------------------------------------------------------------------------------
 "   Vim is Charityware - see ":help license" or uganda.txt for licence details.

--- a/compiler/gnat.vim
+++ b/compiler/gnat.vim
@@ -73,7 +73,7 @@ execute "CompilerSet errorformat=" . escape (g:gnat.Error_Format, ' ')
 let &cpo = s:keepcpo
 unlet s:keepcpo
 
-finish " 1}}}
+finish " }}}1
 
 "------------------------------------------------------------------------------
 "   Vim is Charityware - see ":help license" or uganda.txt for licence details.

--- a/ftdetect/ada.vim
+++ b/ftdetect/ada.vim
@@ -24,7 +24,7 @@ let s:loaded_ftdetect_ada=45
 
 autocmd BufNewFile,BufRead *.gpr setfiletype ada
 
-finish " 1}}}
+finish " }}}1
 
 "------------------------------------------------------------------------------
 "   Vim is Charityware - see ":help license" or uganda.txt for licence details.

--- a/ftplugin/ada.vim
+++ b/ftplugin/ada.vim
@@ -206,13 +206,13 @@ call ada#Map_Menu (
 
 endif
 
-" 1}}}
+" }}}1
 
 " Reset cpoptions
 let &cpoptions = s:cpoptions
 unlet s:cpoptions
 
-finish " 1}}}
+finish " }}}1
 
 "------------------------------------------------------------------------------
 "   Vim is Charityware - see ":help license" or uganda.txt for licence details.

--- a/indent/ada.vim
+++ b/indent/ada.vim
@@ -301,7 +301,7 @@ endfunction GetAdaIndent
 let &cpo = s:keepcpo
 unlet s:keepcpo
 
-finish " 1}}}
+finish " }}}1
 
 "------------------------------------------------------------------------------
 "   Vim is Charityware - see ":help license" or uganda.txt for licence details.

--- a/syntax/ada.vim
+++ b/syntax/ada.vim
@@ -370,7 +370,7 @@ syntax sync minlines=1 maxlines=1
 let &cpo = s:keepcpo
 unlet s:keepcpo
 
-finish " 1}}}
+finish " }}}1
 
 "------------------------------------------------------------------------------
 "   Vim is Charityware - see ":help license" or uganda.txt for licence details.


### PR DESCRIPTION
The fold level comes after the foldmarker for both the opening and closing markers.

I only noticed this because I use a conceal char on foldmarkers and the level
wasn't being hidden.
