### PR TITLE
Refactor: use a list to build the s:AdaBlockStart indent pattern

### DIFF
--- a/indent/ada.vim
+++ b/indent/ada.vim
@@ -43,11 +43,58 @@ endif
 let s:keepcpo= &cpo
 set cpo&vim
 
+" NOTE: let-heredocs are a recent feature addition
+" let s:BlockStartPatterns = [
+" 	 \ 'if\>',
+" 	 \ 'while\>',
+" 	 \ 'else\>',
+" 	 \ 'elsif\>',
+" 	 \ 'loop\>',
+" 	 \ 'for\>.*\<\(loop\|use\)\>',
+" 	 \ 'declare\>',
+" 	 \ 'begin\>',
+" 	 \ 'type\>.*\<is\>[^;]*$',
+" 	 \ '\(type\>.*\)\=\<record\>',
+" 	 \ 'procedure\>',
+" 	 \ 'function\>',
+" 	 \ 'accept\>',
+" 	 \ 'do\>',
+" 	 \ 'task\>',
+" 	 \ 'package\>',
+" 	 \ 'then\>',
+" 	 \ 'when\>',
+" 	 \ 'is\>',
+" 	 \ 'private\>'
+" \]
+
+let s:BlockStartPatterns =<< trim EOS
+   if\>
+   while\>
+   else\>
+   elsif\>
+   loop\>
+   for\>.*\<\(loop\|use\)\>
+   declare\>
+   begin\>
+   type\>.*\<is\>[^;]*$
+   \(type\>.*\)\=\<record\>
+   procedure\>
+   function\>
+   accept\>
+   do\>
+   task\>
+   package\>
+   then\>
+   when\>
+   is\>
+   private\>
+EOS
+
 if exists("g:ada_with_gnat_project_files")
-   let s:AdaBlockStart = '^\s*\(if\>\|while\>\|else\>\|elsif\>\|loop\>\|for\>.*\<\(loop\|use\)\>\|declare\>\|begin\>\|type\>.*\<is\>[^;]*$\|\(type\>.*\)\=\<record\>\|procedure\>\|function\>\|accept\>\|do\>\|task\>\|package\>\|project\>\|then\>\|when\>\|is\>\|private\>\)'
-else
-   let s:AdaBlockStart = '^\s*\(if\>\|while\>\|else\>\|elsif\>\|loop\>\|for\>.*\<\(loop\|use\)\>\|declare\>\|begin\>\|type\>.*\<is\>[^;]*$\|\(type\>.*\)\=\<record\>\|procedure\>\|function\>\|accept\>\|do\>\|task\>\|package\>\|then\>\|when\>\|is\>\|private\>\)'
+   call add(s:BlockStartPatterns, 'project\>')
 endif
+
+let s:AdaBlockStart = '^\s*\(' . join(s:BlockStartPatterns, '\|') . '\)'
 
 " Section: s:MainBlockIndent {{{1
 "


### PR DESCRIPTION
I found this pattern a bit hard to scan for differences and when adding an item.  It's probably a matter of taste as to whether this change is an improvement.

let-heredocs are a new feature for Vim/Neovim (available in the latest releases of both).  I'm unsure whether this project is intended to just track the latest version of Vim that it is distributed in or if it's also supposed to work with older versions.
